### PR TITLE
Makefile: replaced mkdir/cp/chmod with 'install'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,8 @@ seedrng.8: seedrng.8.scdoc
 	scdoc < seedrng.8.scdoc > $@
 
 install: all
-	mkdir -p ${DESTDIR}${PREFIX}/sbin
-	mkdir -p ${DESTDIR}${MANPREFIX}/man8
-	cp -f seedrng ${DESTDIR}${PREFIX}/sbin/
-	cp -f seedrng.8 ${DESTDIR}${MANPREFIX}/man8/
-	chmod 0755 ${DESTDIR}${PREFIX}/sbin/seedrng
-	chmod 0644 ${DESTDIR}${MANPREFIX}/man8/seedrng.8
+	install -Dm 0755 seedrng ${DESTDIR}${PREFIX}/sbin/seedrng
+	install -Dm 0644 seedrng.8 ${DESTDIR}${MANPREFIX}/man8/seedrng.8
 
 uninstall:
 	rm -f ${DESTDIR}${PREFIX}/sbin/seedrng


### PR DESCRIPTION
Using `install` instead of `mkdir/cp/chmod`. Gives you less to write overall and is available in any Linux environment with busybox/toybox/uutils/coreutils or equivalent userland.